### PR TITLE
Potential fix for code scanning alert no. 3: Workflow does not contain permissions

### DIFF
--- a/.github/workflows/test-evaller.yml
+++ b/.github/workflows/test-evaller.yml
@@ -1,4 +1,6 @@
 name: evaller test
+permissions:
+  contents: read
 
 on:
   push:


### PR DESCRIPTION
Potential fix for [https://github.com/mkaraki/IllustStore/security/code-scanning/3](https://github.com/mkaraki/IllustStore/security/code-scanning/3)

To fix the issue, add an explicit `permissions` block limiting GITHUB_TOKEN access to least privilege, at either the workflow or job level. In this workflow, since none of the steps need write permissions (no writing to repository contents, no publishing artifacts to GitHub, etc.), the minimal permission needed is `contents: read`. This can be set at the root of the workflow YAML, so it applies to all jobs by default. 

You should edit the `.github/workflows/test-evaller.yml` file at the top, immediately after the `name:` line, and add the explicit `permissions:` block:

```yaml
permissions:
  contents: read
```

No additional methods, logic, or imports are required - this is a pure YAML configuration change.

---


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
