### PR TITLE
Potential fix for code scanning alert no. 2: Workflow does not contain permissions

### DIFF
--- a/.github/workflows/sentry-release.yml
+++ b/.github/workflows/sentry-release.yml
@@ -4,6 +4,8 @@ on:
   push:
     branches: [ "master" ]
 
+permissions:
+  contents: read
 jobs:
 
   build:


### PR DESCRIPTION
Potential fix for [https://github.com/mkaraki/IllustStore/security/code-scanning/2](https://github.com/mkaraki/IllustStore/security/code-scanning/2)

To fix the problem, you should add a `permissions` block at either the workflow root (applies to all jobs) or at the individual job level (applies only to that job). Since there is only one job in this workflow and no root-level permissions are set, the simplest fix is to add a minimal `permissions` block. The recommended minimum privilege for most workflows performing release or CI actions (without pushing code or writing issues) is `contents: read`. Therefore, insert:

```yaml
permissions:
  contents: read
```

at the root, between the `on:` block and the `jobs:` key, so it applies to all present and future jobs.

No further imports, methods, or definitions are required, as this is a YAML settings change.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
